### PR TITLE
Added Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,29 @@
+FROM nvidia/cuda:8.0-cudnn6-devel-ubuntu16.04
+
+RUN apt update && apt install -y python3-pip    \
+                                 libhdf5-dev    \
+                                 libopencv-dev  \
+                                 python3-tk     \
+                                 cmake          \
+                                 gcc-4.8        \
+                                 g++-4.8        \
+                                 cmake          \
+                                 x11-apps
+
+RUN python3 -m pip install numpy==1.12.1            \
+                           tensorflow-gpu===1.4.0   \
+                           pillow==2.0.0            \
+                           pyparsing===2.1.4        \
+                           cycler===0.10.0          \
+                           matplotlib===2.1.2
+ADD . /home/demon
+RUN mkdir /home/demon/lmbspecialops/build
+WORKDIR /home/demon/lmbspecialops/build
+ENV CC=/usr/bin/gcc-4.8
+ENV CXX=/usr/bin/g++-4.8
+RUN cmake -DCMAKE_BUILD_TYPE=Release ..
+RUN make
+ENV PYTHONPATH=/home/demon/lmbspecialops/python
+ENV LMBSPECIALOPS_LIB=/home/demon/lmbspecialops/build/lib/lmbspecialops.so
+WORKDIR /home/demon/examples
+CMD ["python3", "example.py"]

--- a/README.md
+++ b/README.md
@@ -118,8 +118,35 @@ Note that due to a bug that some of the dataset files with the prefix ```rgbd```
 The affected files have been replaced and now have the prefix ```rgbd_bugfix```.
 MD5 checksums for all files can be found in the file ```traindata.md5```.
 
+## Docker build
+Ensure Docker is installed on your system, and that the default Docker runtime
+is Nvidia:
+
+```
+{
+  "runtimes": {
+    "nvidia": {
+      "path": "/usr/bin/nvidia-container-runtime",
+        "runtimeArgs": []
+    }
+  },
+  "default-runtime": "nvidia"
+}
+```
+
+Then issue the Docker build command:
+
+```
+$ docker build . -t demon
+```
+
+To visualize the example:
+
+```
+$ docker run --gpus all -it -e DISPLAY -v /tmp/.X11-unix:/tmp/.X11-unix:ro demon
+```
+
 
 ## License
 
 DeMoN is under the [GNU General Public License v3.0](LICENSE.txt)
-


### PR DESCRIPTION
Supports "example.py", but does not render 3d points. There is also a bit of a discrepancy, because the README calls for Tensorflow 1.4, but the Tensorflow cmake build script calls "tf.sysconfig.get_compile_flags()", which is only supported from Tensorflow 1.5? In any event, this Dockerfile is sufficient to visualize the depth imagery. 